### PR TITLE
Fix problem in to string conversion of fields

### DIFF
--- a/django_jalali/db/models.py
+++ b/django_jalali/db/models.py
@@ -7,7 +7,7 @@ import django
 import jdatetime
 from django.core import exceptions
 from django.db import models
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_str, smart_text
 from django.utils.functional import curry
 from django.utils.translation import ugettext as _
 
@@ -164,12 +164,12 @@ class jDateField(models.Field):
             return connection.ops.value_to_db_date(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
-        if val is None:
-            data = ''
+        value = self._get_val_from_obj(obj)
+        if value is None:
+            date_string = ''
         else:
-            data = str(value)
-        return data
+            date_string = smart_text(value)
+        return date_string
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.jDateField}
@@ -314,12 +314,12 @@ class jDateTimeField(jDateField):
             return connection.ops.value_to_db_datetime(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
-        if val is None:
-            data = ''
+        value = self._get_val_from_obj(obj)
+        if value is None:
+            dat_string = ''
         else:
-            data = str(val)
-        return data
+            date_string = smart_text(val)
+        return date_string
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.jDateTimeField}

--- a/django_jalali/db/models.py
+++ b/django_jalali/db/models.py
@@ -168,7 +168,7 @@ class jDateField(models.Field):
         if val is None:
             data = ''
         else:
-            data = "te"  # datetime_safe.new_date(val).strftime("%Y-%m-%d")
+            data = str(value)
         return data
 
     def formfield(self, **kwargs):
@@ -318,8 +318,7 @@ class jDateTimeField(jDateField):
         if val is None:
             data = ''
         else:
-            d = datetime_safe.new_datetime(val)
-            data = d.strftime('%Y-%m-%d %H:%M:%S')
+            data = str(val)
         return data
 
     def formfield(self, **kwargs):


### PR DESCRIPTION
## What's do this PR?
There is a problem in method of value_to_srting of django-jalali model fields that make errors in use this fields with django-restframework.
This pull request solve the problem by:
+ Update `value_to_string` method of jDateField to use `__str__` of jdate type
+ Update `value_to_string` method of jDateTimeField to use `__str__` of jdatetime type