### PR TITLE
accept utf-8 characters in formating

### DIFF
--- a/django_jalali/templatetags/jformat.py
+++ b/django_jalali/templatetags/jformat.py
@@ -17,9 +17,6 @@ def jformat(value, arg=None):
     if arg is None:
         arg = "%c"
     try:
-        # this should be force_text but because jdatetime module didn't handle
-        # unicode strings correctly it's not possible to change it at the moment
-        arg = str(arg)
         return value.strftime(arg)
     except AttributeError:
         return ''


### PR DESCRIPTION
This, can handle Unicode Characters too.
It seems that Django now handles Unicode truly.
Tested in Django 1.10