### PR TITLE
change jformat filter based on jdatetime strftime function change.

### DIFF
--- a/django_jalali/templatetags/jformat.py
+++ b/django_jalali/templatetags/jformat.py
@@ -1,6 +1,8 @@
 from distutils.version import StrictVersion
 import django
 import sys
+from datetime import datetime, date
+import jdatetime
 
 django_version = django.get_version()
 if StrictVersion(django_version) >= StrictVersion('1.9'):
@@ -19,12 +21,10 @@ def jformat(value, arg=None):
     if arg is None:
         arg = "%c"
     try:
-        if StrictVersion(django_version) < StrictVersion('1.8'):
-            if sys.version_info >= (3, ): # python 3
-                arg = str(arg)
-            else: # python2
-                arg = arg.encode('utf-8')
-
+        if isinstance(value, datetime):
+            value = jdatetime.datetime.fromgregorian(datetime=value)
+        elif isinstance(value, date):
+            value = jdatetime.date.fromgregorian(date=value)
         return value.strftime(arg)
     except AttributeError:
         return ''


### PR DESCRIPTION
in django 1.7.x when we load an object from db with `jDateField` or `jDateField` fields, the fields type are `datetime` not `jdatetime`. the problem is `from_db_value` introduced in 1.8, and when we load the object from db the field data do not convert to jdatetime, and `to_python` method in 1.7 must have [SubfieldBase metaclass](https://docs.djangoproject.com/en/1.7/howto/custom-model-fields/#the-subfieldbase-metaclass) to convert data from db.

thus based on my [PR](https://github.com/slashmili/python-jalali/pull/29) on python-jalali, we convert datetime.date and datetime.datetime to jdatetime in jformat filter for fixing this problem.    