### PR TITLE
Fix Django Jalali javascipt files loading when Django Jquery file loaded first.(#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- Fix Django Jalali javascipt files loading when Django Jquery file loaded first
+
 ### Changed
 - Add Python 3.9 support
 - Drop Python 3.4 support

--- a/django_jalali/static/admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc-fa.js
+++ b/django_jalali/static/admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc-fa.js
@@ -1,5 +1,6 @@
 ﻿// Mahdi Hasheminezhad. email: hasheminezhad at gmail dot com (http://hasheminezhad.com)
 jQuery(function($){
+    if (!$.datepicker){$ = django.jQuery;}
 	$.datepicker.regional['fa'] = {
 		calendar: JalaliDate,
 		closeText: 'بستن',

--- a/django_jalali/static/admin/main.js
+++ b/django_jalali/static/admin/main.js
@@ -1,4 +1,5 @@
 $(function () {
+    if (!$.datepicker){$ = django.jQuery;}
     $('.vjDateField').datepicker({
         dateFormat: 'yy-mm-dd',
         changeMonth: true,


### PR DESCRIPTION
Fixes https://github.com/slashmili/django-jalali/issues/102
This happens because the Django JQuery file loaded before Django Jalali javascript files.
I am not a javascript expert but this worked in my machine.

@AminHP Could you please test it and let me know if it works fine?
