### PR TITLE
`setup.cfg` migration + some optimization

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,11 +1,11 @@
-## Is this feature request? Please report it in here: https://github.com/slashmili/django-jalali/discussions/categories/ideas
-## Do you have a question on how to use this library? ask you question in here: https://github.com/slashmili/django-jalali/discussions/categories/q-a
+> :warning: Open an issue if you are facing an unexpected behavior or encountered bugs.
 
-## If ONLY AND ONLY you are facing an unexpected behaviour create an issue
+> :information_source: Is this a feature request? Please report it here: https://github.com/slashmili/django-jalali/discussions/categories/ideas
 
-Please provide your configurations and softwares version
+> :question: Do you have a question on how to use this library? ask your question here: https://github.com/slashmili/django-jalali/discussions/categories/q-a
 
-* Python version:
-* Django version: 
-* django_jalali version:
-* OS: 
+#### Configurations
+- Python version:
+- Django version:
+- django_jalali version:
+- OS:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pip-log.txt
 .idea
 
 db.sqlite3
+
+#Vscode
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
-        language_version: python3.8
         args:
           - "--target-version"
           - "py37"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,43 @@
+[metadata]
+name = django-jalali
+version = 6.0.0
+description = Jalali Date support for Django model and admin interface
+url = http://github.com/slashmili/django-jalali
+download_url = http://github.com/slashmili/django-jalali/tarball/master
+author = Milad Rastian
+author_email = eslashmili@gmail.com
+keywords = django jalali
+license = Python Software Foundation License
+platforms = any
+long_description = file: README.rst
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Framework :: Django
+    Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
+
+[options]
+packages = find:
+include_package_data = True
+zip_safe = False
+install_requires =
+    jdatetime>=4.0.0
+    django>=3.2
+
+[options.extras_require]
+drf = djangorestframework>=3.12
+
 [flake8]
 max-line-length = 110
 

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
-setup(
-    name="django-jalali",
-    version="6.0.0",
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
-    description=("Jalali Date support for Django model and admin interface"),
-    url="http://github.com/slashmili/django-jalali",
-    download_url="http://github.com/slashmili/django-jalali/tarball/master",
-    author="Milad Rastian",
-    author_email="eslashmili@gmail.com",
-    keywords="django jalali",
-    license="Python Software Foundation License",
-    platforms="any",
-    install_requires=["jdatetime>=4.0.0", "django>=3.2"],
-    extras_require={"drf": "djangorestframework>=3.12"},
-    long_description=open("README.rst", encoding="utf-8").read(),
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Framework :: Django",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
-        "Framework :: Django :: 4.1",
-    ],
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
Since you are storing all metadata in `setup.py` file, I think that would be much better if you migrate all those data into the INI file.

Improvements:
- setuptools configurations parsed to `config.cfg`
- `language_version` removed from pre-commit Black hook (It now uses the default Python version)
- vscode configs directory added to `.gitignore`