### PR TITLE
Update jdatime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
+## [6.1.1] - 2024-03-27
 ### Changed
+- Use jdatetime 5.0.0
 - Drop Python 3.7 support
 - Confirm Python 3.12 support
 - Drop Django 4.1 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [6.1.1] - 2024-03-27
+## [6.1.0] - 2024-03-26
 ### Changed
 - Use jdatetime 5.0.0
 - Drop Python 3.7 support

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find:
 include_package_data = True
 zip_safe = False
 install_requires =
-    jdatetime>=4.0.0
+    jdatetime>=5.0.0
     django>=3.2
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-jalali
-version = 6.0.1
+version = 6.1.0
 description = Jalali Date support for Django model and admin interface
 url = http://github.com/slashmili/django-jalali
 download_url = http://github.com/slashmili/django-jalali/tarball/master


### PR DESCRIPTION
to use jdatetime 5.0.0

considering jdatetime major bump only had one breaking change(which was a bug) I think it's ok if we force the users to use jdatetime 5.0.0.