### PR TITLE
Fix datepicker for inline admin

### DIFF
--- a/django_jalali/static/admin/css/main.css
+++ b/django_jalali/static/admin/css/main.css
@@ -1,3 +1,7 @@
 img.ui-datepicker-trigger {
-    height: 15px;
+    height: 16px;
+    width: 16px;
+    margin-top: auto;
+    margin-bottom: auto;
+    padding: 5px;
 }

--- a/django_jalali/static/admin/main.js
+++ b/django_jalali/static/admin/main.js
@@ -1,11 +1,32 @@
 $(function () {
+    function activateDatepicker() {
+        $('.vjDateField').each(function() {
+            var inputId = $(this).attr('id') || '';
+            if (inputId.includes('__prefix__')) {
+                return;
+            }
+
+            $(this).datepicker({
+                dateFormat: "yy-mm-dd",
+                changeMonth: true,
+                changeYear: true,
+                showOn: "both",
+                buttonImage: "/static/admin/jquery.ui.datepicker.jalali/themes/base/images/icon-calendar.svg",
+                buttonImageOnly: true,
+                isRTL: false,
+                buttonText: "یک تاریخ انتخاب کنید",
+            });
+        });
+    }
+
     if (!$.datepicker){$ = django.jQuery;}
-    $('.vjDateField').datepicker({
-        dateFormat: 'yy-mm-dd',
-        changeMonth: true,
-        changeYear: true,
-        showOn: 'button',
-        buttonImage: '/static/admin/jquery.ui.datepicker.jalali/themes/base/images/icon-calendar.svg',
-        buttonImageOnly: true
+    activateDatepicker();
+
+    $(document).on('formset:added', function(event, $row, formsetName) {
+        activateDatepicker();
+    });
+
+    $(document).on('formset:removed', function(event, $row, formsetName) {
+        activateDatepicker();
     });
 });


### PR DESCRIPTION
fix #255

### Description of Changes

There were two main issues with the datepicker functionality:

1. **Datepicker Executing on Inactive Inputs**: In inline admin forms, the datepicker was being executed on inputs that were not yet active (those containing `__prefix__` in their IDs).

2. **Reactivating Datepicker After Adding or Removing Formsets**: In forms using formsets, when a new form was added or an existing one was removed, the datepicker was not reinitialized for the new inputs.

Also, changes were made to the position and look of the calendar icon and button text to match Django's style.

### Testing

I tested these changes in Django versions 4.2 and 5.1. Below are screenshots showing the updated datepicker in both tabular and stacked inline forms.

**Tabular Inline**

![image](https://github.com/user-attachments/assets/a06c2253-a44b-4275-af1c-802074bb7aa6)

**Stacked Inline**

![image](https://github.com/user-attachments/assets/79a8d155-528a-4ed6-b9a0-90d5f8a650b8)
