### PR TITLE
Add django jalali settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,41 @@ Usage
 
   $ python manage.py startapp foo
 
-3. Edit settings.py_ and add django_jalali and your foo to your INSTALLED_APPS (also config DATABASES setting)
+3. Edit your Django project's ``settings.py`` file to include ``django_jalali`` and your application in the ``INSTALLED_APPS`` list. Make sure that ``django_jalali`` is listed **before** your apps for proper functionality.
 
-    django_jalali should be added **before** your apps in order to work properly
+   Additionally, you can configure library settings using the ``JALALI_SETTINGS`` dictionary. If a setting is not explicitly defined, the default values will be used.
+
+   .. code-block:: python
+
+      # settings.py
+      INSTALLED_APPS = [
+          "django.contrib.admin",
+          "django.contrib.auth",
+          "django.contrib.contenttypes",
+          "django.contrib.sessions",
+          "django.contrib.messages",
+          "django.contrib.staticfiles",
+          "django_jalali",  # Place this before your custom apps
+      ]
+
+      JALALI_SETTINGS = {
+          # JavaScript static files for the admin Jalali date widget
+          "ADMIN_JS_STATIC_FILES": [
+              "admin/jquery.ui.datepicker.jalali/scripts/jquery-1.10.2.min.js",
+              "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.core.js",
+              "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc.js",
+              "admin/jquery.ui.datepicker.jalali/scripts/calendar.js",
+              "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc-fa.js",
+              "admin/main.js",
+          ],
+          # CSS static files for the admin Jalali date widget
+          "ADMIN_CSS_STATIC_FILES": {
+              "all": [
+                  "admin/jquery.ui.datepicker.jalali/themes/base/jquery-ui.min.css",
+                  "admin/css/main.css",
+              ]
+          },
+      }
 
 4. Edit foo/models.py_
 

--- a/django_jalali/admin/widgets.py
+++ b/django_jalali/admin/widgets.py
@@ -1,32 +1,17 @@
 from django import forms
 from django.contrib.admin.widgets import AdminTimeWidget
-from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from django_jalali import forms as jforms
+from django_jalali.settings import jalali_settings
 
 
 class AdminjDateWidget(jforms.jDateInput):
-    @property
-    def media(self):
-        js = [
-            "jquery.ui.datepicker.jalali/scripts/jquery-1.10.2.min.js",
-            "jquery.ui.datepicker.jalali/scripts/jquery.ui.core.js",
-            "jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc.js",
-            "jquery.ui.datepicker.jalali/scripts/calendar.js",
-            "jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc-fa.js",
-            "main.js",
-        ]
 
-        css = {
-            "all": [
-                "admin/jquery.ui.datepicker.jalali/themes/base/jquery-ui.min.css",
-                "admin/css/main.css",
-            ]
-        }
-
-        return forms.Media(js=[static("admin/%s" % path) for path in js], css=css)
+    class Media:
+        js = jalali_settings.ADMIN_JS_STATIC_FILES
+        css = jalali_settings.ADMIN_CSS_STATIC_FILES
 
     def __init__(self, attrs=None, format=None):
         final_attrs = {"class": "vjDateField", "size": "10"}

--- a/django_jalali/settings.py
+++ b/django_jalali/settings.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.core.signals import setting_changed
 
 DEFAULTS = {
+    # JavaScript static files for the admin Jalali date widget
     "ADMIN_JS_STATIC_FILES": [
         "admin/jquery.ui.datepicker.jalali/scripts/jquery-1.10.2.min.js",
         "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.core.js",
@@ -10,6 +11,7 @@ DEFAULTS = {
         "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc-fa.js",
         "admin/main.js",
     ],
+    # CSS static files for the admin Jalali date widget
     "ADMIN_CSS_STATIC_FILES": {
         "all": [
             "admin/jquery.ui.datepicker.jalali/themes/base/jquery-ui.min.css",

--- a/django_jalali/settings.py
+++ b/django_jalali/settings.py
@@ -1,0 +1,67 @@
+from django.conf import settings
+from django.core.signals import setting_changed
+
+DEFAULTS = {
+    "ADMIN_JS_STATIC_FILES": [
+        "admin/jquery.ui.datepicker.jalali/scripts/jquery-1.10.2.min.js",
+        "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.core.js",
+        "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc.js",
+        "admin/jquery.ui.datepicker.jalali/scripts/calendar.js",
+        "admin/jquery.ui.datepicker.jalali/scripts/jquery.ui.datepicker-cc-fa.js",
+        "admin/main.js",
+    ],
+    "ADMIN_CSS_STATIC_FILES": {
+        "all": [
+            "admin/jquery.ui.datepicker.jalali/themes/base/jquery-ui.min.css",
+            "admin/css/main.css",
+        ]
+    },
+}
+
+
+class JalaliSetting:
+    def __init__(self, defaults=None):
+        self._defaults = defaults or DEFAULTS
+        self._attrs = set()
+
+    @property
+    def user_settings(self):
+        if not hasattr(self, "_user_settings"):
+            self._user_settings = getattr(settings, "JALALI_SETTINGS", {})
+
+        return self._user_settings
+
+    def __getattr__(self, attr):
+        if attr not in self._defaults:
+            raise AttributeError(f"Invalid Jalali setting: {attr}")
+
+        try:
+            val = self.user_settings[attr]
+        except KeyError:
+            val = self._defaults[attr]
+
+        # Cache the result
+        self._attrs.add(attr)
+        setattr(self, attr, val)
+
+        return val
+
+    def reload(self):
+        for attr in self._attrs:
+            delattr(self, attr)
+
+        self._attrs.clear()
+        if hasattr(self, "_user_settings"):
+            delattr(self, "_user_settings")
+
+
+jalali_settings = JalaliSetting()
+
+
+def reload_jalali_settings(*args, **kwargs):
+    setting = kwargs["setting"]
+    if setting == "JALALI_SETTINGS":
+        jalali_settings.reload()
+
+
+setting_changed.connect(reload_jalali_settings)


### PR DESCRIPTION
close #266 

### Description of Changes

- Added a settings class for accessing `JALALI_SETTINGS` in `settings.py`.
- Added `ADMIN_JS_STATIC_FILES` and `ADMIN_CSS_STATIC_FILES` settings.
- Refactored`AdminjDateWidget` media handling.
- Added documentation for settings and defaults.

### Testing

- [x] Tested with Django 4.2
- [x] Tested with Django 5.1